### PR TITLE
Fix key input

### DIFF
--- a/thumble_001_arduino/thumble_001_arduino.ino
+++ b/thumble_001_arduino/thumble_001_arduino.ino
@@ -296,7 +296,8 @@ void loop() {
         } else {
             // record new state.
             keyWasDown[ii] = keyIsDown[ii];
-            keyIsDown[ii] = digitalRead(keyToPin[ii]);
+            // we have pull-ups on the input pins, so they will read LOW when pressed and HIGH otherwise.
+            keyIsDown[ii] = ! digitalRead(keyToPin[ii]);
         }
     }
 

--- a/thumble_001_arduino/thumble_001_arduino.ino
+++ b/thumble_001_arduino/thumble_001_arduino.ino
@@ -298,6 +298,7 @@ void loop() {
             keyWasDown[ii] = keyIsDown[ii];
             // we have pull-ups on the input pins, so they will read LOW when pressed and HIGH otherwise.
             keyIsDown[ii] = ! digitalRead(keyToPin[ii]);
+            coolDown[ii] = KEY_COOLDOWN;
         }
     }
 
@@ -310,10 +311,8 @@ void loop() {
         // when a key is pressed, send event and restart the cooldown timer
         if (keyWasDown[ii] && ! keyIsDown[ii]) {
             onKeyUp(ii);
-            coolDown[ii] = KEY_COOLDOWN;
         } else if (! keyWasDown[ii] && keyIsDown[ii]) {
             onKeyDown(ii);
-            coolDown[ii] = KEY_COOLDOWN;
         } else if (keyIsDown[ii]) {
             onKeyStillDown(ii);
         }

--- a/thumble_001_arduino/thumble_001_arduino.ino
+++ b/thumble_001_arduino/thumble_001_arduino.ino
@@ -253,7 +253,7 @@ void setup() {
 
     // keyswitch pins: input
     for (int ii = 0; ii < NUM_KEYS; ii++) {
-        pinMode(keyToPin[ii], INPUT);
+        pinMode(keyToPin[ii], INPUT_PULLUP);
         keyIsDown[ii] = false;
         keyWasDown[ii] = false;
         coolDown[ii] = 0;


### PR DESCRIPTION
This PR fixes a few little things with the key reading:

- Enables pull-up resistors on the inputs so that pressing the switches pulls them to ground.
- Inverts the reading of the switches so that 0 = Note On and 1 = Note Off.
- Fixes the cooldown locking notes on/off. Resetting the cooldown to the max value in the "react to key events" section was causing the notes to get locked in the on state once pressed. I'm a bit rusty at c++, but it looks like this section: ```if (coolDown[ii] != 0) {
            continue;
        }``` was meant to fix that.. but for some reason it didn't. 